### PR TITLE
fix: Long retries

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -25,5 +25,22 @@ jobs:
         npm test
       env:
         CI: true
-    - name: JSR Publish Test  
+    - name: JSR Publish Test
       run: npm run test:jsr
+
+  emfile_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: npm install and build
+      run: |
+        npm install
+        npm run build --if-present
+      env:
+        CI: true
+    - name: Run EMFILE test
+      run: npm run test:emfile

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ tests/fixtures/typescript-project/index.js
 
 # file used to generate env.d.ts
 dist/env.js
+
+tmp

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:unit": "mocha tests/retrier.test.js",
     "test:build": "node tests/pkg.test.cjs && node tests/pkg.test.mjs",
     "test:jsr": "npx jsr@latest publish --dry-run",
+    "test:emfile": "node tools/check-emfile-handling.js",
     "test": "npm run test:unit && npm run test:build"
   },
   "repository": {

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview A utility to test that ESLint doesn't crash with EMFILE/ENFILE errors.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import fs from "node:fs";
+import { readFile } from "node:fs/promises";
+import { Retrier } from "../src/retrier.js";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const OUTPUT_DIRECTORY = "tmp/emfile-check";
+const FILE_COUNT = 15000;
+
+/**
+ * Generates files in a directory.
+ * @returns {void}
+ */
+function generateFiles() {
+
+    fs.mkdirSync(OUTPUT_DIRECTORY, { recursive: true });
+
+    for (let i = 0; i < FILE_COUNT; i++) {
+        const fileName = `file_${i}.js`;
+        const fileContent = `// This is file ${i}`;
+
+        fs.writeFileSync(`${OUTPUT_DIRECTORY}/${fileName}`, fileContent);
+    }
+
+}
+
+/**
+ * Generates an EMFILE error by reading all files in the output directory.
+ * @returns {Promise<Buffer[]>} A promise that resolves with the contents of all files.
+ */
+function generateEmFileError() {
+    return Promise.all(
+        Array.from({ length: FILE_COUNT }, (_, i) => {
+            const fileName = `file_${i}.js`;
+
+            return readFile(`${OUTPUT_DIRECTORY}/${fileName}`);
+        })
+    );
+}
+
+/**
+ * Generates an EMFILE error by reading all files in the output directory with retries.
+ * @returns {Promise<Buffer[]>} A promise that resolves with the contents of all files.
+ */ 
+function generateEmFileErrorWithRetry() {
+    const retrier = new Retrier(error => error.code === "EMFILE" || error.code === "ENFILE");
+
+    return Promise.all(
+        Array.from({ length: FILE_COUNT }, (_, i) => {
+            const fileName = `file_${i}.js`;
+
+            return retrier.retry(() => readFile(`${OUTPUT_DIRECTORY}/${fileName}`));
+        })
+    );    
+}
+
+//------------------------------------------------------------------------------
+// Main
+//------------------------------------------------------------------------------
+
+console.log(`Generating ${FILE_COUNT} files in ${OUTPUT_DIRECTORY}...`);
+generateFiles();
+
+console.log("Checking that this number of files would cause an EMFILE error...");
+generateEmFileError()
+    .then(() => {
+        throw new Error("EMFILE error not encountered.");
+    })
+    .catch(error => {
+        if (error.code === "EMFILE") {
+            console.log("✅ EMFILE error encountered:", error.message);
+        } else if (error.code === "ENFILE") {
+            console.log("✅ ENFILE error encountered:", error.message);
+        } else {
+            console.error("❌ Unexpected error encountered:", error.message);
+            throw error;
+        }
+    }).then(() => {
+
+        console.log("Running with retry...");
+        return generateEmFileErrorWithRetry()
+            .then(() => {
+                console.log("✅ No errors encountered with retry.");
+            })
+            .catch(error => {
+                console.error("❌ Unexpected error encountered with retry:", error.message);
+                throw error;
+            });
+
+    });


### PR DESCRIPTION
ESLint reported that some users were still getting EMFILE errors even with using Retry. 

The primary problem is that `#processQueue` was being called recursively, and when a lot of retries were necessary, this caused a stack overflow error.

There was another problem where a failed task was pushed to the front of the queue, allowing it to fail repeatedly while other tasks in the queue sat without being evaluated. Those tasks would then end up timing out and throwing the EMFILE error that they held.

This PR fixes both issues:

1. Ensures that `#processQueue` is always called either with `setTimeout()` or in a promise resolver
2. Failed tasks are pushed to the back of the queue to wait for another turn rather than the front.

I also added a test for fails for long retries prior to this fix. This will now be run as part of CI.



Refs https://github.com/eslint/eslint/issues/18977