### PR TITLE
fix: Look for specific DEBUG value before outputting debug messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ const text = await retrier.retry(
 3. Run `npm install` to setup dependencies
 4. Run `npm test` to run tests
 
+### Debug Output
+
+Enable debugging output by setting the `DEBUG` environment variable to `"@hwc/retry"` before running.
+
 ## License
 
 Apache 2.0

--- a/src/retrier.js
+++ b/src/retrier.js
@@ -22,8 +22,8 @@ const MAX_CONCURRENCY = 1000;
  * @returns {void}
  */
 function debug(message) {
-    if (globalThis?.process?.env.DEBUG) {
-        console.log(message);
+    if (globalThis?.process?.env.DEBUG === "@hwc/retry") {
+        console.debug(message);
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to improve debugging capabilities and documentation for the retry mechanism.

Refs https://github.com/eslint/eslint/issues/19101

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R167): Added instructions for enabling debugging output by setting the `DEBUG` environment variable to `"@hwc/retry"`.

Debugging improvements:

* [`src/retrier.js`](diffhunk://#diff-3b5f7b9a24986a3226457a3df2960add4f4a28a3e614c79be994c09a0056464aL25-R26): Modified the `debug` function to check if the `DEBUG` environment variable is set to `"@hwc/retry"` and use `console.debug` for logging.