### PR TITLE
fix: handle rejections from temporary promises

### DIFF
--- a/src/retrier.js
+++ b/src/retrier.js
@@ -309,20 +309,20 @@ export class Retrier {
         promise.finally(() => {
             this.#working--;
             this.#processPending();
-        });
+        })
+        // `promise.finally` creates a new promise that may be rejected, so it must be handled.
+            .catch(() => { });
 
         // call the original function and catch any ENFILE or EMFILE errors
-        // @ts-ignore because we know it's any
-        return Promise.resolve(result)
+        Promise.resolve(result)
             .then(value => {
                 debug("Function called successfully without retry.");
                 resolve(value);
-                return promise;
             })
             .catch(error => {
                 if (!this.#check(error)) {
                     reject(error);
-                    return promise;
+                    return;
                 }
 
                 const task = new RetryTask(fn, error, resolve, reject, signal);
@@ -336,9 +336,9 @@ export class Retrier {
                 });
 
                 this.#processQueue();
-
-                return promise;
             });
+        
+        return promise;
     }
 
     /**

--- a/tests/retrier.test.js
+++ b/tests/retrier.test.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Tests for the Retrier class.
  */
-/*global describe, it, AbortSignal, AbortController, setTimeout */
+/* global beforeEach, afterEach, describe, it, AbortSignal, AbortController, setTimeout */
 
 //-----------------------------------------------------------------------------
 // Requirements
@@ -28,6 +28,24 @@ describe("Retrier", () => {
     });
 
     describe("retry()", () => {
+
+        let caughtUnhandledRejection;
+
+        function unhandledRejectionListener(err) {
+            caughtUnhandledRejection = err;
+        }
+
+        beforeEach(() => {
+            process.addListener("unhandledRejection", unhandledRejectionListener);
+            caughtUnhandledRejection = null;
+        });
+
+        afterEach(() => {
+            process.removeListener("unhandledRejection", unhandledRejectionListener);
+
+            // Ensure that no unhandled promise rejection has occurred.
+            assert.ifError(caughtUnhandledRejection);
+        });
         
         it("should retry a function that rejects an error", async () => {
 


### PR DESCRIPTION
This pull request ensures that local (temporary) promises created inside the `#call` method are properly handled when they are rejected, so that the process does not terminate unexpectedly.

This problem was originally reported in eslint/eslint#19243, and I checked that this fix does indeed fix that error.

The following is a repro specific to this package, which is expected to print `"Hello, World!"` but does currently fail with an `"Unexpected Error"` exception:

```js
import { Retrier } from "@humanwhocodes/retry";

setTimeout(() => {
    console.log("Hello, World!");
}, 100);

try {
    const retrier = new Retrier(() => false);
    await retrier.retry(async () => {
        throw new Error("Unexpected Error");
    });
} catch {
    // swallow error
}

```

Refs eslint/eslint#19243