### PR TITLE
fix: improve type def for Retrier.retry

### DIFF
--- a/src/retrier.js
+++ b/src/retrier.js
@@ -343,11 +343,12 @@ export class Retrier {
 
     /**
      * Adds a new retry job to the queue.
-     * @param {Function} fn The function to call.
+     * @template {(...args: unknown[]) => Promise<unknown>} T
+     * @template {Awaited<ReturnType<T>>} R
+     * @param {T} fn The function to call.
      * @param {object} [options] The options for the job.
      * @param {AbortSignal} [options.signal] The AbortSignal to monitor for cancellation.
-     * @returns {Promise<any>} A promise that resolves when the queue is
-     *  processed.
+     * @returns {Promise<R>} A promise that resolves when the queue is processed.
      */
     retry(fn, { signal } = {}) {
 

--- a/src/retrier.js
+++ b/src/retrier.js
@@ -343,12 +343,12 @@ export class Retrier {
 
     /**
      * Adds a new retry job to the queue.
-     * @template {(...args: unknown[]) => Promise<unknown>} T
-     * @template {Awaited<ReturnType<T>>} R
-     * @param {T} fn The function to call.
+     * @template {(...args: unknown[]) => Promise<unknown>} Func
+     * @template {Awaited<ReturnType<Func>>} RetVal
+     * @param {Func} fn The function to call.
      * @param {object} [options] The options for the job.
      * @param {AbortSignal} [options.signal] The AbortSignal to monitor for cancellation.
-     * @returns {Promise<R>} A promise that resolves when the queue is processed.
+     * @returns {Promise<RetVal>} A promise that resolves when the queue is processed.
      */
     retry(fn, { signal } = {}) {
 


### PR DESCRIPTION
This change makes a minor improvement to the type definition for the retry function.

Before:
![Screenshot 2025-05-06 at 10 24 40 AM](https://github.com/user-attachments/assets/973f85b0-5865-4830-b685-075d871ceeac)

After:
![Screenshot 2025-05-06 at 10 24 16 AM](https://github.com/user-attachments/assets/957d4325-c021-466a-97b6-e261bdedac62)
